### PR TITLE
 policy: Show a simple dialog about optimizing apps

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -22,7 +22,7 @@ import android.app.ActivityManagerInternal.SleepToken;
 import android.app.ActivityManagerNative;
 import android.app.AppOpsManager;
 import android.app.IUiModeManager;
-import android.app.ProgressDialog;
+import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.app.StatusBarManager;
 import android.app.UiModeManager;
@@ -6735,7 +6735,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         screenTurnedOn();
     }
 
-    ProgressDialog mBootMsgDialog = null;
+    AlertDialog mBootMsgDialog = null;
 
     /**
      * name of package currently being dex optimized
@@ -6766,7 +6766,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                         theme = 0;
                     }
 
-                    mBootMsgDialog = new ProgressDialog(mContext, theme) {
+                    mBootMsgDialog = new AlertDialog(mContext, theme) {
                         // This dialog will consume all events coming in to
                         // it, to avoid it trying to do things too early in boot.
                         @Override public boolean dispatchKeyEvent(KeyEvent event) {
@@ -6806,6 +6806,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     lp.screenOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR;
                     mBootMsgDialog.getWindow().setAttributes(lp);
                     mBootMsgDialog.setCancelable(false);
+                    mBootMsgDialog.setMessage("");
                     mBootMsgDialog.show();
                 }
 


### PR DESCRIPTION
I just really like this alot and cherry-picked it myself, and I dont have any actual data, but it did feel as if apps got optimized a little bit quicker. Try for yourself. :)

NOT MY ORIGINAL CODE OR COMMIT.

http://review.cyanogenmod.org/#/c/131627/

When booting, new apps are optimized with dex2oat. During this process a
progress dialog is displayed (optimizing app 13/74). This dialog has an
indetemninate progress spinner that uses 50% of cpu.

This leaves only 50% for dex2oat, prolonging the time to boot.
